### PR TITLE
Update air date

### DIFF
--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -86,6 +86,7 @@ export default {
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
+          arrival_time: this.arrival_time,
           user_id: this.$store.state.auth.currentUser.id
           //カラムたくさん追加します
           //カラムたくさん追加します
@@ -98,6 +99,8 @@ export default {
         this.departure_place = "";
         this.arrival_place = "";
         this.departure_time = "";
+        this.arrival_time = "";
+
 
       } else {
         const train_params = {

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -85,6 +85,7 @@ export default {
           travel_id: data.id,
           departure_place: this.departure_place,
           arrival_place: this.arrival_place,
+          departure_time: this.departure_time,
           user_id: this.$store.state.auth.currentUser.id
           //カラムたくさん追加します
           //カラムたくさん追加します

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -19,7 +19,7 @@
         </v-col>
           <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
-            
+
       </template>
 
       <template v-if="transport === 'air'">
@@ -55,8 +55,8 @@ export default {
       name: "",
       departure_place: "",
       arrival_place: "",
-      departure_time: null,
-      arrival_time: null,
+      departure_time: "",
+      arrival_time: "",
 
       success: false,
     };

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -29,6 +29,7 @@
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
+        <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
       </template>
 
       <v-col cols="12" md="4">

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -97,6 +97,8 @@ export default {
         console.log(res_air);
         this.departure_place = "";
         this.arrival_place = "";
+        this.departure_time = "";
+
       } else {
         const train_params = {
           travel_id: data.id,

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -28,6 +28,7 @@
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         </v-col>
+        <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
       </template>
 
       <v-col cols="12" md="4">


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#22 
旅行情報新規登録関連
# 変更内容
条件分岐でairを選択した場合の表示する入力フォームの変更をしました。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
<img width="259" alt="スクリーンショット 2021-01-03 19 16 08" src="https://user-images.githubusercontent.com/71075728/103476353-269d4000-4df8-11eb-9dd5-fa6c90138243.png">

![スクリーンショット 2021-01-03 19 16 49](https://user-images.githubusercontent.com/71075728/103476362-3ddc2d80-4df8-11eb-8779-d0575781fe0c.png)

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
returnで返す値を＝””,空に変更。
決定ボタン押下後時間選択フォームがそのまま。
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
railsのターミナル上でparameterに値が渡っているのを確認しました。
consoe.logにも表示し確認しました。