### PR TITLE
Fix depaeture day

### DIFF
--- a/tabimae-api/app/controllers/v1/travels_controller.rb
+++ b/tabimae-api/app/controllers/v1/travels_controller.rb
@@ -1,4 +1,9 @@
 class V1::TravelsController < ApplicationController
+
+  def index
+    travel = Travel.all
+  end
+
   def create
     travel = Travel.new(travel_params)
     if travel.save

--- a/tabimae-web/layouts/default.vue
+++ b/tabimae-web/layouts/default.vue
@@ -131,8 +131,8 @@ export default {
     background-size: 100%;
   }
   .bg {
-    background-color: #DDDDDD;
+    background-color: black;
     background-size: 100%;
-    color: #444444;
+    color: #ffffff;
   }
 </style>

--- a/tabimae-web/nuxt.config.js
+++ b/tabimae-web/nuxt.config.js
@@ -40,8 +40,13 @@ export default {
     // https://go.nuxtjs.dev/vuetify
     '@nuxtjs/vuetify',
     '@nuxtjs/dotenv',
+    '@nuxtjs/moment'
 
   ],
+  moment: {
+    // ここにオプションが記述できる
+    locales: ['ja']
+  },
 
   // Modules (https://go.nuxtjs.dev/config-modules)
   modules: [

--- a/tabimae-web/package-lock.json
+++ b/tabimae-web/package-lock.json
@@ -1989,6 +1989,18 @@
         "dotenv": "^8.1.0"
       }
     },
+    "@nuxtjs/moment": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/moment/-/moment-1.6.1.tgz",
+      "integrity": "sha512-Mo2/3NQB0XryMQuNCTVnAclrDvt9I9sr6dwVm56KhYCoiWTKgQ78tDV9tmrxw7lahw1IBwyPGhw+3pwkM4phAA==",
+      "dev": true,
+      "requires": {
+        "moment": "^2.25.3",
+        "moment-locales-webpack-plugin": "^1.2.0",
+        "moment-timezone": "^0.5.28",
+        "moment-timezone-data-webpack-plugin": "^1.3.0"
+      }
+    },
     "@nuxtjs/proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.1.0.tgz",
@@ -4167,6 +4179,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+    },
+    "date-fns": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
+      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -6629,6 +6646,12 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
     "lodash.kebabcase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
@@ -6959,6 +6982,40 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
+    "moment-locales-webpack-plugin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz",
+      "integrity": "sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==",
+      "dev": true,
+      "requires": {
+        "lodash.difference": "^4.5.0"
+      }
+    },
+    "moment-timezone": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
+    "moment-timezone-data-webpack-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-timezone-data-webpack-plugin/-/moment-timezone-data-webpack-plugin-1.3.0.tgz",
+      "integrity": "sha512-0V0xnHZpdHLsSerIQ2yNEPBC3uJWfU/zNT3nB0PO+tjmGHuNeUWqNDiw7ZpLo54uER6/OAE75EJ7ThmlwkGuZw==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^3.0.0",
+        "make-dir": "^3.0.0"
       }
     },
     "move-concurrently": {

--- a/tabimae-web/package.json
+++ b/tabimae-web/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.21.0",
     "core-js": "^3.6.5",
     "css-loader": "^5.0.1",
+    "date-fns": "^2.16.1",
     "firebase": "^8.1.2",
     "nuxt": "^2.14.6",
     "vue2-timepicker": "^1.1.5",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@nuxtjs/dotenv": "^1.4.1",
+    "@nuxtjs/moment": "^1.6.1",
     "@nuxtjs/vuetify": "^1.11.2"
   }
 }

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -1,58 +1,54 @@
 <template>
-  <div>
-    <h1>旅行一覧ページ</h1>
-    <nuxt-link to="/travel_new">新規登録</nuxt-link>
-    <v-data-table :headers="headers" :items="travels">
-      <template v-slot:item.action="{ item }">
-        <v-icon small @click="deleteItem(item)">delete</v-icon>
-      </template>
-    </v-data-table>
-  </div>
+  <v-card>
+    <v-card-title>
+      旅行一覧
+      <v-spacer></v-spacer>
+      <!-- <v-text-field
+        v-model="search"
+        append-icon="search"
+        label="Search"
+        single-line
+        hide-details
+      ></v-text-field> -->
+    </v-card-title>
+    <v-data-table
+      :items="transport"
+    ></v-data-table>
+  </v-card>
 </template>
 
 <script>
-import axios from "@/plugins/axios";
+import TravelNew from "@/pages/travel_new";
 
 export default {
-  props: ["travels"], // <- これ！
+  // components: {
+  //   TravelNew,
+  // },
   data() {
     return {
-      singleSelect: true,
-      selected: [],
-      search: "",
-      headers: [
-        {
-          text: "タイトル",
-          align: "left",
-          sortable: false,
-          value: "title"
-        },
-        { text: "ユーザー名", value: "username" },
-        { text: "Actions", value: "action", sortable: false }
-      ]
-    };
-  },
-  computed: {
-    user() {
-      return this.$store.state.currentUser;
-    }
-  },
-  methods: {
-    async deleteItem(item) {
-      const res = confirm("本当に削除しますか？");
-      if (res) {
-        await axios.delete(`/v1/todos/${item.id}`);
-        const todos = this.user.todos.filter(todo => {
-          return todo.id !== item.id;
-        });
-        const newUser = {
-          ...this.user,
-          todos
+      // travel_params: "",
+      //   {
+      // travel: "",
+      transport: "",
+      // name: "",
+      // departure_place: "",
+      // arrival_place: "",
+      // departure_time: "",
+      // arrival_time: "",
+
         };
-        this.$store.commit("setUser", newUser);
-      }
-    }
-  }
+      // ],
+      // search: "",
+      // headers: [
+      //   {
+      //     text: "タイトル",
+      //     align: "left",
+      //     sortable: false,
+      //     value: "title",
+      //   },
+      //   { text: "ユーザー名", value: "username" },
+      // ],
+  },
 };
 </script>
 

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -25,9 +25,9 @@
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
+                label="出発日"
                 :value="departure_day"
                 clearable
-                :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
@@ -36,9 +36,8 @@
             </template>
             <v-date-picker
               v-model="departure_day"
-              @change="choice_departure_day = false"
+              @change="choice_departure_day = departure_day"
             ></v-date-picker>
-
           </v-menu>
 
         </v-col>
@@ -51,27 +50,27 @@
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
         <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
-          <v-menu
-            v-model="choice_departure_day"
+        <v-menu
+            v-model="departure_day"
             :close-on-content-click="false"
             max-width="290"
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="departure_day"
+                :value="setday"
                 clearable
                 :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="departure_day = null"
+                @click:clear="choice_departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="departure_day"
-              @change="choice_departure_day = false"
+              v-model="choice_departure_day"
+              @change="setday = choice_departure_day"
             ></v-date-picker>
-
+          </v-menu>
         </v-col>
       </template>
 
@@ -107,10 +106,8 @@ export default {
       departure_time: "",
       arrival_time: "",
       departure_day: "",
-      setday: "出発日",
-      choice_departure_day: format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'),
       success: false,
-      menu1: true,
+      choice_departure_day : false,
     };
 
 

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -51,24 +51,24 @@
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
         <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
         <v-menu
-            v-model="departure_day"
+            v-model="choice_departure_day"
             :close-on-content-click="false"
             max-width="290"
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="setday"
+                label="出発日"
+                :value="departure_day"
                 clearable
-                :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="choice_departure_day = null"
+                @click:clear="departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="choice_departure_day"
-              @change="setday = choice_departure_day"
+              v-model="departure_day"
+              @change="choice_departure_day = departure_day"
             ></v-date-picker>
           </v-menu>
         </v-col>

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -51,6 +51,27 @@
         </v-col>
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
         <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
+        <v-menu
+            v-model="departure_day"
+            :close-on-content-click="false"
+            max-width="290"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <v-text-field
+                :value="label"
+                clearable
+                :label="label"
+                readonly
+                v-bind="attrs"
+                v-on="on"
+                @click:clear="departure_day_date = null"
+              ></v-text-field>
+            </template>
+            <v-date-picker
+              v-model="departure_day_date"
+              @change="label = departure_day_date"
+            ></v-date-picker>
+          </v-menu>
       </template>
 
       <v-col cols="12" md="4">

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -26,18 +26,18 @@
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="label"
+                :value="setday"
                 clearable
-                :label="label"
+                :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="departure_day_date = null"
+                @click:clear="choice_departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="departure_day_date"
-              @change="label = departure_day_date"
+              v-model="choice_departure_day"
+              @change="setday = choice_departure_day"
             ></v-date-picker>
           </v-menu>
 
@@ -58,18 +58,18 @@
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="label"
+                :value="setday"
                 clearable
-                :label="label"
+                :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="departure_day_date = null"
+                @click:clear="choice_departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="departure_day_date"
-              @change="label = departure_day_date"
+              v-model="choice_departure_day"
+              @change="setday = choice_departure_day"
             ></v-date-picker>
           </v-menu>
       </template>
@@ -106,8 +106,8 @@ export default {
       departure_time: "",
       arrival_time: "",
       departure_day: "",
-      label: "出発日",
-      departure_day_date: format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'),
+      setday: "出発日",
+      choice_departure_day: format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'),
       success: false,
     };
 
@@ -183,7 +183,7 @@ export default {
       this.$store.state.auth.currentUser;
     },
     departure_day () {
-      return this.departure_day_date ? moment(this.departure_day_date).format('dddd, MMMM Do YYYY') : ''
+      return this.choice_departure_day ? moment(this.choice_departure_daye).format('dddd, MMMM Do YYYY') : ''
     },
 
   },

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -38,6 +38,7 @@
               v-model="departure_day"
               @change="menu1 = false"
             ></v-date-picker>
+            
           </v-menu>
 
         </v-col>

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -19,7 +19,7 @@
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
 
           <v-menu
-            v-model="menu1"
+            v-model="choice_departure_day"
             :close-on-content-click="false"
             max-width="290"
           >
@@ -36,9 +36,9 @@
             </template>
             <v-date-picker
               v-model="departure_day"
-              @change="menu1 = false"
+              @change="choice_departure_day = false"
             ></v-date-picker>
-            
+
           </v-menu>
 
         </v-col>

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -19,24 +19,24 @@
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
 
           <v-menu
-            v-model="departure_day"
+            v-model="menu1"
             :close-on-content-click="false"
             max-width="290"
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="setday"
+                :value="departure_day"
                 clearable
                 :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="choice_departure_day = null"
+                @click:clear="departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="choice_departure_day"
-              @change="setday = choice_departure_day"
+              v-model="departure_day"
+              @change="menu1 = false"
             ></v-date-picker>
           </v-menu>
 
@@ -80,7 +80,7 @@
 
       <v-btn @click="createTravel">決定</v-btn>
       {{ user }}
-      <!-- {{ departure_day }} -->
+      <!-- {{ departure_day_test }} -->
     </v-container>
   </div>
 </template>
@@ -109,6 +109,7 @@ export default {
       setday: "出発日",
       choice_departure_day: format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'),
       success: false,
+      menu1: true,
     };
 
 
@@ -135,13 +136,8 @@ export default {
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
           arrival_time: this.arrival_time,
-          choice_departure_day: this.departure_day,
-          // departure_day_date: this.departure_day_date,
+          departure_day: this.departure_day,
           user_id: this.$store.state.auth.currentUser.id
-          //カラムたくさん追加します
-          //カラムたくさん追加します
-          //カラムたくさん追加します
-          //カラムたくさん追加します
         };
         console.log(air_params);
         const res_air = await axios.post("/v1/airs", { air: air_params });
@@ -182,9 +178,9 @@ export default {
       return
       this.$store.state.auth.currentUser;
     },
-    departure_day () {
-      return this.choice_departure_day ? moment(this.choice_departure_daye).format('dddd, MMMM Do YYYY') : ''
-    },
+    // departure_day_test () {
+    //   return this.choice_departure_day ? moment(this.choice_departure_daye).format('dddd, MMMM Do YYYY') : ''
+    // },
 
   },
   created () {

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -5,7 +5,7 @@
     <v-container class="px-0" fluid>
       <v-container fluid>
         <v-radio-group v-model="transport" mandatory>
-          <v-radio label="列車" value="train"></v-radio>
+          <v-radio class="test" label="列車" value="train"></v-radio>
           <v-radio label="飛行機" value="air"></v-radio>
         </v-radio-group>
       </v-container>
@@ -15,8 +15,7 @@
         <v-col cols="12" md="4">
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
-        </v-col>
-          <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
+          <p>出発時間 </p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
 
           <v-menu
@@ -41,6 +40,7 @@
             ></v-date-picker>
           </v-menu>
 
+        </v-col>
       </template>
 
       <template v-if="transport === 'air'">
@@ -48,7 +48,6 @@
         <v-col cols="12" md="4">
           <v-text-field v-model="departure_place" :counter="10" label="出発地" required></v-text-field>
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
-        </v-col>
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
         <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
         <v-menu
@@ -72,6 +71,7 @@
               @change="setday = choice_departure_day"
             ></v-date-picker>
           </v-menu>
+        </v-col>
       </template>
 
       <v-col cols="12" md="4">
@@ -135,7 +135,7 @@ export default {
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
           arrival_time: this.arrival_time,
-          departure_day: this.departure_day,
+          choice_departure_day: this.departure_day,
           // departure_day_date: this.departure_day_date,
           user_id: this.$store.state.auth.currentUser.id
           //カラムたくさん追加します

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -19,6 +19,28 @@
           <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
           <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
 
+          <v-menu
+            v-model="departure_day"
+            :close-on-content-click="false"
+            max-width="290"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <v-text-field
+                :value="label"
+                clearable
+                :label="label"
+                readonly
+                v-bind="attrs"
+                v-on="on"
+                @click:clear="departure_day_date = null"
+              ></v-text-field>
+            </template>
+            <v-date-picker
+              v-model="departure_day_date"
+              @change="label = departure_day_date"
+            ></v-date-picker>
+          </v-menu>
+
       </template>
 
       <template v-if="transport === 'air'">
@@ -37,14 +59,18 @@
 
       <v-btn @click="createTravel">決定</v-btn>
       {{ user }}
+      <!-- {{ departure_day }} -->
     </v-container>
   </div>
 </template>
 
 <script>
 import axios from "@/plugins/axios";
-import VueTimepicker from 'vue2-timepicker'
-import 'vue2-timepicker/dist/VueTimepicker.css'
+import VueTimepicker from 'vue2-timepicker';
+import 'vue2-timepicker/dist/VueTimepicker.css';
+import moment from 'moment';
+import { format, parseISO } from 'date-fns';
+
 export default {
   components: {
       'vue-timepicker': VueTimepicker,
@@ -58,7 +84,9 @@ export default {
       arrival_place: "",
       departure_time: "",
       arrival_time: "",
-
+      departure_day: "",
+      label: "出発日",
+      departure_day_date: format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'),
       success: false,
     };
 
@@ -86,6 +114,8 @@ export default {
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
           arrival_time: this.arrival_time,
+          departure_day: this.departure_day,
+          // departure_day_date: this.departure_day_date,
           user_id: this.$store.state.auth.currentUser.id
           //カラムたくさん追加します
           //カラムたくさん追加します
@@ -126,9 +156,18 @@ export default {
     user() {
       return
       this.$store.state.auth.currentUser;
-    }
+    },
+    departure_day () {
+      return this.departure_day_date ? moment(this.departure_day_date).format('dddd, MMMM Do YYYY') : ''
+    },
 
+  },
+  created () {
+    console.log(format(parseISO(new Date().toISOString()), 'yyyy-MM-dd'));
   }
 };
 </script>
 
+<style>
+
+</style>

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -51,27 +51,27 @@
           <v-text-field v-model="arrival_place" :counter="10" label="到着地" required></v-text-field>
         <p>出発時間</p><vue-timepicker v-model="departure_time" format="A:h:mm:"></vue-timepicker>
         <p>到着時間</p><vue-timepicker v-model="arrival_time" format="A:h:mm:"></vue-timepicker>
-        <v-menu
-            v-model="departure_day"
+          <v-menu
+            v-model="choice_departure_day"
             :close-on-content-click="false"
             max-width="290"
           >
             <template v-slot:activator="{ on, attrs }">
               <v-text-field
-                :value="setday"
+                :value="departure_day"
                 clearable
                 :setday="setday"
                 readonly
                 v-bind="attrs"
                 v-on="on"
-                @click:clear="choice_departure_day = null"
+                @click:clear="departure_day = null"
               ></v-text-field>
             </template>
             <v-date-picker
-              v-model="choice_departure_day"
-              @change="setday = choice_departure_day"
+              v-model="departure_day"
+              @change="choice_departure_day = false"
             ></v-date-picker>
-          </v-menu>
+
         </v-col>
       </template>
 

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -150,6 +150,7 @@ export default {
         this.arrival_place = "";
         this.departure_time = "";
         this.arrival_time = "";
+        this.departure_day = "";
 
 
       } else {
@@ -159,6 +160,7 @@ export default {
           arrival_place: this.arrival_place,
           departure_time: this.departure_time,
           arrival_time: this.arrival_time,
+          departure_day: this.departure_day,
           user_id: this.$store.state.auth.currentUser.id
         };
         console.log(train_params);
@@ -168,6 +170,8 @@ export default {
         this.arrival_place = "";
         this.departure_time = "";
         this.arrival_time = "";
+        this.departure_day = "";
+
 
       }
       // this.$router.push 詳細画面へ遷移。


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#24 
列車、飛行機選択時に出発日が登録できるようになりました。
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
import moment from 'moment';
import { format, parseISO } from 'date-fns';
をし、外部のライブラリを使用しました
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
外部ライブラリをインストールしました。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
実際にparameterに飛んでくるのは <v-date-picker>内のdeparture_dayです。
![スクリーンショット 2021-01-04 22 34 26](https://user-images.githubusercontent.com/71075728/103540434-04312280-4edd-11eb-8d26-2dfd45bb66e9.png)
