### PR TITLE
Fix travel list UI

### DIFF
--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -15,25 +15,25 @@
         </v-col>
       </v-row>
     </v-container>
-    <v-simple-table class="list-table">
+    <v-simple-table class="list-table" style="color:#001858">
       <thead>
         <tr>
-          <th>
+          <th style="color:#001858">
             詳細
           </th>
-          <th>
+          <th style="color:#001858">
             出発日
           </th>
-          <th>
+          <th style="color:#001858">
             出発地
           </th>
-          <th>
+          <th style="color:#001858">
             到着地
           </th>
-          <th>
+          <th style="color:#001858">
             出発時間
           </th>
-          <th>
+          <th style="color:#001858">
             到着時間
           </th>
         </tr>
@@ -146,5 +146,11 @@
   }
 .list-table{
   background-color:#f3d2c1;
+  // font-size: 100px;
+  color: red;
 }
+.list-th{
+  color: red;
+}
+
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -11,21 +11,31 @@
               <span class="title">旅行一覧</span>
             </v-card-title>
           </v-card>
-          <v-card elevation="20" color=#f3d2c1>
-            <v-ul v-for="travel in travelData.data">
-              <!-- <li>{{ travel.transport }}</li> -->
+        </v-col>
+      </v-row>
+    </v-container>
 
-              <v-ul v-for="train in travel.trains">
-                <v-row>
-                <v-col cols="12" sm="6" md="6" lg="12">
+      <v-ul v-for="travel in travelData.data">
+        <v-container>
+    <v-card elevation="20" color=#f3d2c1>
+          <!-- <v-row> -->
+            <!-- <li>{{ travel.transport }}</li> -->
+            <v-ul v-for="train in travel.trains">
+              <v-row>
+                <v-col cols="12" sm="6" md="6" lg="6">
                   <v-li>
-                      <h5 class="item-title">出発日</h5>
+                    <h5 class="item-title">出発日</h5>
                     <v-card-text class="item-text">
                       {{ train.departure_day }}
                     </v-card-text>
                   </v-li>
                 </v-col>
-                </v-row>
+                <v-col cols="12" sm="6" md="6" lg="6">
+                  <v-card-text class="item-text">
+                    <v-li>{{ travel.name }}</v-li>
+                  </v-card-text>
+                </v-col>
+              </v-row>
 
               <v-row>
                 <v-col cols="12" sm="6" md="6" lg="6">
@@ -65,21 +75,14 @@
                     </v-card-text>
                   </v-li>
                 </v-col>
-                </v-row>
-                <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
-              </v-ul>
-              <!-- <ul v-for="train in travel.airs">
-                <li>{{ air.departure_day }}</li>
-              </ul> -->
-              <v-card-title primary-title>
-                <span class="title">旅行テーマ</span>
-                <v-li>{{ travel.name }}</v-li>
-              </v-card-title>
+              </v-row>
+              <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
             </v-ul>
-          </v-card>
-        </v-col>
-      </v-row>
+
+    <!-- </v-row> -->
+    </v-card>
     </v-container>
+    </v-ul>
   </div>
 </template>
 
@@ -163,7 +166,6 @@
   .v-card {
     width: 100%;
     // text-align: center;
-    margin-bottom: 40px;
   }
 
   .v-card-title {
@@ -175,8 +177,20 @@
     color: #001858;
     text-align: center;
   }
-  .item-title{
-    font-size: 20px;
+
+  .item-text {
+    font-size: 23px;
+    color: #001858;
+    // text-shadow:
+    //     1px 0 0 #f582ae,
+    //     0 1px 0 #f582ae,
+    //     -1px 0 0 #f582ae,
+    //     0 -1px 0 #f582ae
+  }
+
+  .item-title {
+    font-size: 15px;
+    color: #001858;
   }
 
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -1,88 +1,143 @@
 <template>
-    <v-card>
-    <h1>一覧</h1>
-    <ul v-for="travel in travelData.data">
-      <li>{{ travel.transport }}</li>
-      <li>{{ travel.name }}</li>
-      <ul v-for="train in travel.trains">
-        <li>{{ train.departure_day }}</li>
-        <li>{{ train.departure_place }}</li>
-        <li>{{ train.arrival_place }}</li>
-        <li>{{ train.departure_time }}</li>
-        <li>{{ train.arrival_time }}</li>
-        <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
-      </ul>
-      <ul v-for="train in travel.airs">
-        <li>{{ air.departure_day }}</li>
-      </ul>
-    </ul>
-  </v-card>
+  <div>
+    <v-container>
+      <v-row>
+        <v-col cols="12" sm="11" md="11" lg="12">
+          <v-card color=#f3d2c1>
+            <v-card-title primary-title class="justify-center">
+              <v-icon large color=#001858>
+                mdi-bag-checked
+              </v-icon>
+              <span class="title">旅行一覧</span>
+            </v-card-title>
+          </v-card>
+          <v-card color=#f3d2c1>
+            <v-ul v-for="travel in travelData.data">
+              <!-- <li>{{ travel.transport }}</li> -->
+              <v-li>{{ travel.name }}</v-li>
+              <v-ul v-for="train in travel.trains">
+                <v-col cols="12" sm="11" md="11" lg="12">
+                  <v-li>
+                    <v-card-text class="item-text">
+                      {{ train.departure_day }}
+                    </v-card-text>
+                  </v-li>
+                </v-col>
+                <v-col cols="12" sm="11" md="11" lg="12">
+                  <v-li>{{ train.departure_place }}</v-li>
+                </v-col>
+                <v-col cols="12" sm="11" md="11" lg="12">
+                  <v-li>{{ train.arrival_place }}</v-li>
+                </v-col>
+                <v-col cols="12" sm="11" md="11" lg="12">
+                  <lv-i>{{ train.departure_time }}</lv-i>
+                </v-col>
+                <v-col cols="12" sm="11" md="11" lg="12">
+                  <v-li>{{ train.arrival_time }}</v-li>
+                </v-col>
+                <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
+              </v-ul>
+              <!-- <ul v-for="train in travel.airs">
+                <li>{{ air.departure_day }}</li>
+              </ul> -->
+            </v-ul>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
 </template>
 
 <script>
-import axios from "@/plugins/axios";
-import TravelNew from "@/pages/travel_new";
+  import axios from "@/plugins/axios";
+  import TravelNew from "@/pages/travel_new";
 
-export default {
-  // components: {
-  //   TravelNew,
-  // },
-  data() {
-    return {
-      // travel_params: "",
-      //   {
-      travelData: {},
-      travel: "",
-      transport: "",
-      userName: {}
-      // name: "",
-      // departure_place: "",
-      // arrival_place: "",
-      // departure_time: "",
-      // arrival_time: "",
-    };
-  },
-  async fetch() {
-    // console.log(this.$store.state.auth.currentUser.id);
-    const user = this.$store.state.auth.currentUser;
-    // debugger
-    if (user) {
-      this.travelData = await axios.get("/v1/travels", { params: { user } });
+  export default {
+    // components: {
+    //   TravelNew,
+    // },
+    data() {
+      return {
+        // travel_params: "",
+        //   {
+        travelData: {},
+        travel: "",
+        transport: "",
+        userName: {}
+        // name: "",
+        // departure_place: "",
+        // arrival_place: "",
+        // departure_time: "",
+        // arrival_time: "",
+      };
+    },
+    async fetch() {
+      // console.log(this.$store.state.auth.currentUser.id);
+      const user = this.$store.state.auth.currentUser;
+      // debugger
+      if (user) {
+        this.travelData = await axios.get("/v1/travels", {
+          params: {
+            user
+          }
+        });
 
-      //filterで作り直された配列がtravelNameに入る
-      console.log(this.travelData);
-    }
-  },
+        //filterで作り直された配列がtravelNameに入る
+        console.log(this.travelData);
+      }
+    },
 
-  // created() {
-  //   this.userName = this.travelData.data.filter(function(value) {
-  //     console.log(value);
-  //   });
-  // },
-  methods: {
-    filteingUserName() {
-      // console.log(this.travelData);
-      // this.userName = this.travelData.data.map(function(value) {
-      //   console.log(value.username.user);
-      //   return value.username;
-      // });
-      // console.log(this.userName);
-    }
-  },
-  computed: {
-    // returnUserName() {
-    //   if (this.travelData !== undefined){ return }
-    //   console.log(this.travelData.data);
-    //   const userName = this.travelData.data.filter(function(value) {
+    // created() {
+    //   this.userName = this.travelData.data.filter(function(value) {
     //     console.log(value);
     //   });
-    //   // return "アイウエオ";
-    // }
-    // user() {
-    //   return this.$store.state.auth.currentUser;
-    // }
-  }
-};
+    // },
+    methods: {
+      filteingUserName() {
+        // console.log(this.travelData);
+        // this.userName = this.travelData.data.map(function(value) {
+        //   console.log(value.username.user);
+        //   return value.username;
+        // });
+        // console.log(this.userName);
+      }
+    },
+    computed: {
+      // returnUserName() {
+      //   if (this.travelData !== undefined){ return }
+      //   console.log(this.travelData.data);
+      //   const userName = this.travelData.data.filter(function(value) {
+      //     console.log(value);
+      //   });
+      //   // return "アイウエオ";
+      // }
+      // user() {
+      //   return this.$store.state.auth.currentUser;
+      // }
+    }
+  };
+
 </script>
 
-<style></style>
+<style lang="scss" scoped>
+  .item-text {
+    color: red;
+  }
+
+  .v-card {
+    width: 100%;
+    // text-align: center;
+    margin-bottom: 40px;
+  }
+
+  .v-card-title {
+    text-align: center;
+    font-weight: bolder;
+  }
+
+  .title {
+    color: #001858;
+    text-align: center;
+  }
+
+</style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -153,4 +153,5 @@
   color: red;
 }
 
+
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -15,7 +15,7 @@
         </v-col>
       </v-row>
     </v-container>
-    <v-simple-table>
+    <v-simple-table class="list-table">
       <thead>
         <tr>
           <th>
@@ -144,5 +144,7 @@
     margin-bottom: 30px;
 
   }
-
+.list-table{
+  background-color:#f3d2c1;
+}
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -11,14 +11,15 @@
               <span class="title">旅行一覧</span>
             </v-card-title>
           </v-card>
-          <v-card color=#f3d2c1>
+          <v-card elevation="20" color=#f3d2c1>
             <v-ul v-for="travel in travelData.data">
               <!-- <li>{{ travel.transport }}</li> -->
 
               <v-ul v-for="train in travel.trains">
                 <v-row>
-                <v-col cols="12" sm="11" md="11" lg="12">
+                <v-col cols="12" sm="6" md="6" lg="12">
                   <v-li>
+                      <h5 class="item-title">出発日</h5>
                     <v-card-text class="item-text">
                       {{ train.departure_day }}
                     </v-card-text>
@@ -27,16 +28,18 @@
                 </v-row>
 
               <v-row>
-                <v-col cols="12" sm="11" md="11" lg="6">
+                <v-col cols="12" sm="6" md="6" lg="6">
                   <v-li>
+                    <h5 class="item-title">出発地</h5>
                     <v-card-text class="item-text">
                       {{ train.departure_place }}
                     </v-card-text>
                   </v-li>
                 </v-col>
 
-                <v-col cols="12" sm="11" md="11" lg="6">
+                <v-col cols="12" sm="6" md="6" lg="6">
                   <v-li>
+                    <h5 class="item-title">到着地</h5>
                     <v-card-text class="item-text">
                       {{ train.arrival_place }}
                     </v-card-text>
@@ -45,16 +48,18 @@
               </v-row>
 
               <v-row>
-                <v-col cols="12" sm="11" md="11" lg="6">
-                  <lv-i>
+                <v-col cols="12" sm="6" md="6" lg="6">
+                  <v-li>
+                    <h5 class="item-title">出発時間</h5>
                     <v-card-text class="item-text">
                       {{ train.departure_time }}
                     </v-card-text>
-                  </lv-i>
+                  </v-li>
                 </v-col>
 
-                <v-col cols="12" sm="11" md="11" lg="6">
+                <v-col cols="12" sm="6" md="6" lg="6">
                   <v-li>
+                    <h5 class="item-title">到着時間</h5>
                     <v-card-text class="item-text">
                       {{ train.arrival_time }}
                     </v-card-text>
@@ -151,8 +156,8 @@
 
 <style lang="scss" scoped>
   .item-text {
-    color: red;
-    font-size: 35px;
+    color: #001858;
+    // font-size: 35px;
   }
 
   .v-card {
@@ -169,6 +174,9 @@
   .title {
     color: #001858;
     text-align: center;
+  }
+  .item-title{
+    font-size: 20px;
   }
 
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -16,6 +16,7 @@
               <!-- <li>{{ travel.transport }}</li> -->
 
               <v-ul v-for="train in travel.trains">
+                <v-row>
                 <v-col cols="12" sm="11" md="11" lg="12">
                   <v-li>
                     <v-card-text class="item-text">
@@ -23,8 +24,10 @@
                     </v-card-text>
                   </v-li>
                 </v-col>
+                </v-row>
 
-                <v-col cols="12" sm="11" md="11" lg="12">
+              <v-row>
+                <v-col cols="12" sm="11" md="11" lg="6">
                   <v-li>
                     <v-card-text class="item-text">
                       {{ train.departure_place }}
@@ -32,15 +35,17 @@
                   </v-li>
                 </v-col>
 
-                <v-col cols="12" sm="11" md="11" lg="12">
+                <v-col cols="12" sm="11" md="11" lg="6">
                   <v-li>
                     <v-card-text class="item-text">
                       {{ train.arrival_place }}
                     </v-card-text>
                   </v-li>
                 </v-col>
+              </v-row>
 
-                <v-col cols="12" sm="11" md="11" lg="12">
+              <v-row>
+                <v-col cols="12" sm="11" md="11" lg="6">
                   <lv-i>
                     <v-card-text class="item-text">
                       {{ train.departure_time }}
@@ -48,13 +53,14 @@
                   </lv-i>
                 </v-col>
 
-                <v-col cols="12" sm="11" md="11" lg="12">
+                <v-col cols="12" sm="11" md="11" lg="6">
                   <v-li>
                     <v-card-text class="item-text">
                       {{ train.arrival_time }}
                     </v-card-text>
                   </v-li>
                 </v-col>
+                </v-row>
                 <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
               </v-ul>
               <!-- <ul v-for="train in travel.airs">

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -14,7 +14,7 @@
           <v-card color=#f3d2c1>
             <v-ul v-for="travel in travelData.data">
               <!-- <li>{{ travel.transport }}</li> -->
-              <v-li>{{ travel.name }}</v-li>
+
               <v-ul v-for="train in travel.trains">
                 <v-col cols="12" sm="11" md="11" lg="12">
                   <v-li>
@@ -23,23 +23,47 @@
                     </v-card-text>
                   </v-li>
                 </v-col>
+
                 <v-col cols="12" sm="11" md="11" lg="12">
-                  <v-li>{{ train.departure_place }}</v-li>
+                  <v-li>
+                    <v-card-text class="item-text">
+                      {{ train.departure_place }}
+                    </v-card-text>
+                  </v-li>
                 </v-col>
+
                 <v-col cols="12" sm="11" md="11" lg="12">
-                  <v-li>{{ train.arrival_place }}</v-li>
+                  <v-li>
+                    <v-card-text class="item-text">
+                      {{ train.arrival_place }}
+                    </v-card-text>
+                  </v-li>
                 </v-col>
+
                 <v-col cols="12" sm="11" md="11" lg="12">
-                  <lv-i>{{ train.departure_time }}</lv-i>
+                  <lv-i>
+                    <v-card-text class="item-text">
+                      {{ train.departure_time }}
+                    </v-card-text>
+                  </lv-i>
                 </v-col>
+
                 <v-col cols="12" sm="11" md="11" lg="12">
-                  <v-li>{{ train.arrival_time }}</v-li>
+                  <v-li>
+                    <v-card-text class="item-text">
+                      {{ train.arrival_time }}
+                    </v-card-text>
+                  </v-li>
                 </v-col>
                 <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
               </v-ul>
               <!-- <ul v-for="train in travel.airs">
                 <li>{{ air.departure_day }}</li>
               </ul> -->
+              <v-card-title primary-title>
+                <span class="title">旅行テーマ</span>
+                <v-li>{{ travel.name }}</v-li>
+              </v-card-title>
             </v-ul>
           </v-card>
         </v-col>
@@ -122,6 +146,7 @@
 <style lang="scss" scoped>
   .item-text {
     color: red;
+    font-size: 35px;
   }
 
   .v-card {

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -4,7 +4,7 @@
     <v-container>
       <v-row>
         <v-col cols="12" sm="11" md="11" lg="12">
-          <v-card color=#f3d2c1>
+          <v-card color=#f3d2c1 elevation=“20”>
             <v-card-title primary-title class="justify-center">
               <v-icon large color=#001858>
                 mdi-bag-checked
@@ -15,54 +15,63 @@
         </v-col>
       </v-row>
     </v-container>
-    <v-simple-table class="list-table" style="color:#001858">
-      <thead>
-        <tr>
-          <th style="color:#001858">
-            詳細
-          </th>
-          <th style="color:#001858">
-            出発日
-          </th>
-          <th style="color:#001858">
-            出発地
-          </th>
-          <th style="color:#001858">
-            到着地
-          </th>
-          <th style="color:#001858">
-            出発時間
-          </th>
-          <th style="color:#001858">
-            到着時間
-          </th>
-        </tr>
-      </thead>
+
+    <v-container>
+      <v-row>
+        <v-col cols="12" sm="11" md="11" lg="12">
+          <v-card elevation=“20” color=#f3d2c1>
+            <v-table class="list-table" style="color:#001858">
+              <thead>
+                <tr>
+                  <th style="color:#001858">
+                    詳細
+                  </th>
+                  <th style="color:#001858">
+                    出発日
+                  </th>
+                  <th style="color:#001858">
+                    出発地
+                  </th>
+                  <th style="color:#001858">
+                    到着地
+                  </th>
+                  <th style="color:#001858">
+                    出発時間
+                  </th>
+                  <th style="color:#001858">
+                    到着時間
+                  </th>
+                </tr>
+              </thead>
 
 
-        <li v-for="travel in travelData.data">
-      <tbody>
-          <router-link style="text-decoration: none; color: inherit;" :to="`/travel/${travel.id}`">
-            <!-- <v-card elevation="20" color=#f3d2c1> -->
-            <!-- <router-link style=“text-decoration: none; color: inherit;” :to=“`/travel/${travel.id}`“>詳細へ遷移
+              <!-- <v-card elevation="20" color=#f3d2c1> -->
+              <!-- <router-link style=“text-decoration: none; color: inherit;” :to=“`/travel/${travel.id}`“>詳細へ遷移
                   </router-link> -->
-            <tr v-for="train in travel.trains">
-              <!-- <tr v-for="train in travelData.data"> -->
-              <td>
-                <v-btn>aaa</v-btn>
-              </td>
-              <td>{{ train.departure_day }}</td>
-              <td>{{ travel.name }}</td>
-              <td>{{ train.departure_place }}</td>
-              <td>{{ train.arrival_place }}</td>
-              <td>{{ train.departure_time }}</td>
-              <td>{{ train.arrival_time }}</td>
-            </tr>
-            <!-- </v-card> -->
-          </router-link>
-      </tbody>
-        </li>
-    </v-simple-table>
+              <tbody>
+                <tr v-for="travel in travelData.data">
+                  <router-link style="text-decoration: none; color: inherit;" :to="`/travel/${travel.id}`">
+                <tr v-for="train in travel.trains">
+                  <!-- <tr v-for="train in travelData.data"> -->
+                  <td class="show-btn">
+                    <v-icon>mdi-feature-search-outline</v-icon>
+                  </td>
+                  <td>{{ train.departure_day }}</td>
+                  <td>{{ travel.name }}</td>
+                  <td>{{ train.departure_place }}</td>
+                  <td>{{ train.arrival_place }}</td>
+                  <td>{{ train.departure_time }}</td>
+                  <td>{{ train.arrival_time }}</td>
+                </tr>
+                <!-- </v-card> -->
+                </router-link>
+                </tr>
+              </tbody>
+            </v-table>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
   </div>
 </template>
 
@@ -144,14 +153,25 @@
     margin-bottom: 30px;
 
   }
-.list-table{
-  background-color:#f3d2c1;
-  // font-size: 100px;
-  color: red;
-}
-.list-th{
-  color: red;
-}
 
+  .list-table {
+    background-color: #f3d2c1;
+    // font-size: 100px;
+  }
+
+  .show-btn {
+    background-color: #001858;
+    border: solid 3px #001858;
+    /*線*/
+    border-radius: 10px;
+    /*角の丸み*/
+    text-decoration: none;
+    display: flex;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-align-items: center;
+    align-items: center;
+    box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.4);
+  }
 
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -16,6 +16,8 @@
     </v-container>
 
       <v-ul v-for="travel in travelData.data">
+
+        <router-link style="text-decoration: none; color: inherit;" :to="`/travel/${travel.id}`">
         <v-container>
           <v-row>
             <v-col cols="12" sm="6" md="6" lg="12">
@@ -93,6 +95,7 @@
             </v-col>
           </v-row>
     </v-container>
+    </router-link>
     </v-ul>
   </div>
 </template>
@@ -177,11 +180,14 @@
   .v-card {
     width: 100%;
     // text-align: center;
+    margin-bottom: 30px;
+
   }
 
   .v-card-title {
     text-align: center;
     font-weight: bolder;
+
   }
 
   .title {
@@ -231,5 +237,6 @@
     font-size: 18px;
 box-shadow: 10px 10px 10px rgba(0,0,0,0.4);
   }
+
 
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+
     <v-container>
       <v-row>
         <v-col cols="12" sm="11" md="11" lg="12">
@@ -14,89 +15,54 @@
         </v-col>
       </v-row>
     </v-container>
+    <v-simple-table>
+      <thead>
+        <tr>
+          <th>
+            詳細
+          </th>
+          <th>
+            出発日
+          </th>
+          <th>
+            出発地
+          </th>
+          <th>
+            到着地
+          </th>
+          <th>
+            出発時間
+          </th>
+          <th>
+            到着時間
+          </th>
+        </tr>
+      </thead>
 
-      <v-ul v-for="travel in travelData.data">
 
-        <router-link style="text-decoration: none; color: inherit;" :to="`/travel/${travel.id}`">
-        <v-container>
-          <v-row>
-            <v-col cols="12" sm="6" md="6" lg="12">
-    <v-card elevation="20" color=#f3d2c1>
-            <!-- <li>{{ travel.transport }}</li> -->
-            <v-ul v-for="train in travel.trains">
-              <v-row>
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-li>
-                    <h5 class="item-title">出発日</h5>
-                    <v-card-text class="item-text">
-                      {{ train.departure_day }}
-                    </v-card-text>
-                  </v-li>
-                </v-col>
-
-                <v-col cols="12" sm="6" md="6" lg="2">
-                  <v-card-text class="travel-name">
-                    <v-li>{{ travel.name }}</v-li>
-                  </v-card-text>
-                </v-col>
-                  <v-col cols="12" sm="6" md="6" lg="2">
-                  <v-card-text class="travel-show-link">
-                  <v-li>
-                    <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移
-                  </nuxt-link>
-                  </v-li>
-                  </v-card-text>
-                  </v-col>
-              </v-row>
-
-              <v-row>
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-li>
-                    <h5 class="item-title">出発地</h5>
-                    <v-card-text class="item-text">
-                      {{ train.departure_place }}
-                    </v-card-text>
-                  </v-li>
-                </v-col>
-
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-li>
-                    <h5 class="item-title">到着地</h5>
-                    <v-card-text class="item-text">
-                      {{ train.arrival_place }}
-                    </v-card-text>
-                  </v-li>
-                </v-col>
-              </v-row>
-
-              <v-row>
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-li>
-                    <h5 class="item-title">出発時間</h5>
-                    <v-card-text class="item-text">
-                      {{ train.departure_time }}
-                    </v-card-text>
-                  </v-li>
-                </v-col>
-
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-li>
-                    <h5 class="item-title">到着時間</h5>
-                    <v-card-text class="item-text">
-                      {{ train.arrival_time }}
-                    </v-card-text>
-                  </v-li>
-                </v-col>
-              </v-row>
-            </v-ul>
-
-    <!-- </v-row> -->
-    </v-card>
-            </v-col>
-          </v-row>
-    </v-container>
-    </router-link>
-    </v-ul>
+        <li v-for="travel in travelData.data">
+      <tbody>
+          <router-link style="text-decoration: none; color: inherit;" :to="`/travel/${travel.id}`">
+            <!-- <v-card elevation="20" color=#f3d2c1> -->
+            <!-- <router-link style=“text-decoration: none; color: inherit;” :to=“`/travel/${travel.id}`“>詳細へ遷移
+                  </router-link> -->
+            <tr v-for="train in travel.trains">
+              <!-- <tr v-for="train in travelData.data"> -->
+              <td>
+                <v-btn>aaa</v-btn>
+              </td>
+              <td>{{ train.departure_day }}</td>
+              <td>{{ travel.name }}</td>
+              <td>{{ train.departure_place }}</td>
+              <td>{{ train.arrival_place }}</td>
+              <td>{{ train.departure_time }}</td>
+              <td>{{ train.arrival_time }}</td>
+            </tr>
+            <!-- </v-card> -->
+          </router-link>
+      </tbody>
+        </li>
+    </v-simple-table>
   </div>
 </template>
 
@@ -172,71 +138,11 @@
 </script>
 
 <style lang="scss" scoped>
-  .item-text {
-    color: #001858;
-    // font-size: 35px;
-  }
-
   .v-card {
     width: 100%;
     // text-align: center;
     margin-bottom: 30px;
 
   }
-
-  .v-card-title {
-    text-align: center;
-    font-weight: bolder;
-
-  }
-
-  .title {
-    color: #001858;
-    text-align: center;
-  }
-
-  .item-text {
-    font-size: 23px;
-    color: #001858;
-    // text-shadow:
-    //     1px 0 0 #f582ae,
-    //     0 1px 0 #f582ae,
-    //     -1px 0 0 #f582ae,
-    //     0 -1px 0 #f582ae
-    text-align: center;
-  }
-
-  .item-title {
-    font-size: 15px;
-    background-color: #001858;
-    border-top-left-radius: 40px;
-    border-top-right-radius: 40px;
-    border-bottom-right-radius: 40px;
-    border-bottom-left-radius: 40px;
-    color: #f3d2c1;
-    text-align: center;
-  }
-  .travel-name{
-    background-color: #001858;
-    border-top-left-radius: 40px;
-    border-top-right-radius: 40px;
-    border-bottom-right-radius: 40px;
-    border-bottom-left-radius: 40px;
-    color: #f3d2c1;
-    text-align: center;
-    font-size: 18px;
-  }
-  .travel-show-link{
-    background-color: #001858;
-    border-top-left-radius: 40px;
-    border-top-right-radius: 40px;
-    border-bottom-right-radius: 40px;
-    border-bottom-left-radius: 40px;
-    color: #f3d2c1;
-    text-align: center;
-    font-size: 18px;
-box-shadow: 10px 10px 10px rgba(0,0,0,0.4);
-  }
-
 
 </style>

--- a/tabimae-web/pages/travel_list.vue
+++ b/tabimae-web/pages/travel_list.vue
@@ -17,8 +17,9 @@
 
       <v-ul v-for="travel in travelData.data">
         <v-container>
+          <v-row>
+            <v-col cols="12" sm="6" md="6" lg="12">
     <v-card elevation="20" color=#f3d2c1>
-          <!-- <v-row> -->
             <!-- <li>{{ travel.transport }}</li> -->
             <v-ul v-for="train in travel.trains">
               <v-row>
@@ -30,11 +31,20 @@
                     </v-card-text>
                   </v-li>
                 </v-col>
-                <v-col cols="12" sm="6" md="6" lg="6">
-                  <v-card-text class="item-text">
+
+                <v-col cols="12" sm="6" md="6" lg="2">
+                  <v-card-text class="travel-name">
                     <v-li>{{ travel.name }}</v-li>
                   </v-card-text>
                 </v-col>
+                  <v-col cols="12" sm="6" md="6" lg="2">
+                  <v-card-text class="travel-show-link">
+                  <v-li>
+                    <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移
+                  </nuxt-link>
+                  </v-li>
+                  </v-card-text>
+                  </v-col>
               </v-row>
 
               <v-row>
@@ -76,11 +86,12 @@
                   </v-li>
                 </v-col>
               </v-row>
-              <nuxt-link :to="`/travel/${travel.id}`">詳細へ遷移</nuxt-link>
             </v-ul>
 
     <!-- </v-row> -->
     </v-card>
+            </v-col>
+          </v-row>
     </v-container>
     </v-ul>
   </div>
@@ -186,11 +197,39 @@
     //     0 1px 0 #f582ae,
     //     -1px 0 0 #f582ae,
     //     0 -1px 0 #f582ae
+    text-align: center;
   }
 
   .item-title {
     font-size: 15px;
-    color: #001858;
+    background-color: #001858;
+    border-top-left-radius: 40px;
+    border-top-right-radius: 40px;
+    border-bottom-right-radius: 40px;
+    border-bottom-left-radius: 40px;
+    color: #f3d2c1;
+    text-align: center;
+  }
+  .travel-name{
+    background-color: #001858;
+    border-top-left-radius: 40px;
+    border-top-right-radius: 40px;
+    border-bottom-right-radius: 40px;
+    border-bottom-left-radius: 40px;
+    color: #f3d2c1;
+    text-align: center;
+    font-size: 18px;
+  }
+  .travel-show-link{
+    background-color: #001858;
+    border-top-left-radius: 40px;
+    border-top-right-radius: 40px;
+    border-bottom-right-radius: 40px;
+    border-bottom-left-radius: 40px;
+    color: #f3d2c1;
+    text-align: center;
+    font-size: 18px;
+box-shadow: 10px 10px 10px rgba(0,0,0,0.4);
   }
 
 </style>

--- a/tabimae-web/pages/travel_new.vue
+++ b/tabimae-web/pages/travel_new.vue
@@ -273,8 +273,4 @@
     float: left;
   }
 
-  .v-icon {
-    font-size: px;
-  }
-
 </style>


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#97 一覧画面のレイアウト変更
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
tableダグを用いて
詳細画面への遷移ボタン、出発日、出発地、到着地、出発時間、到着時間のデータを並べました。
# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
#96  については後日修正
詳細画面への遷移ボタンの使用は要検討（一覧画面の目的は詳細画面への誘導なのでもっと大きく目立つものにした方が良いかもしれません
<img width="1432" alt="スクリーンショット 2021-01-23 2 19 23" src="https://user-images.githubusercontent.com/71075728/105523171-6d0ffb80-5d21-11eb-9cbc-2e68ae4a0dbe.png">
）