### PR TITLE
fix-ログイン後のTOP画面のボタンを変えました

### DIFF
--- a/tabimae-web/pages/index.vue
+++ b/tabimae-web/pages/index.vue
@@ -1,7 +1,49 @@
 <template>
   <div class="test">
     <Home />
-    <v-container>
+
+    <v-container v-if="user">
+
+      <v-row>
+        <div class="page">
+          <div class="buttons">
+            <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="3" lg="8">
+              <ButtonDefault to="/travel_new" class="button">
+                <template v-slot:label>
+                  <v-icon large color="#001858">mdi-account-plus</v-icon>タビ新規登録
+                  <p class="btn-text">まずは、旅行情報を登録してみよう</p>
+                </template>
+              </ButtonDefault>
+            </v-col>
+            <v-col cols="12" sm="8" xs="12" offset-md="3" md="9" offset-lg="3" lg="8">
+              <ButtonDefault to="/travel_list" class="button">
+                <template v-slot:label>
+                  <v-icon large color="#001858">mdi-account-search</v-icon>タビ一覧
+                  <p class="btn-text">登録したタビの一覧を確認できます</p>
+                </template>
+              </ButtonDefault>
+            </v-col>
+          </div>
+        </div>
+      </v-row>
+
+      <v-card color="#f3d2c1">
+        <v-card-title primary-title class="justify-center">
+          <v-icon large color="#001858">mdi-bag-checked</v-icon>
+          <span class="title">旅行出発前に知っておきたいこと</span>
+        </v-card-title>
+        <v-card-text color="#001858">
+          <p>画像をクリックすると知っておきたい情報をチェックできます</p>
+        </v-card-text>
+        <v-row>
+          <Train />
+          <Air />
+          <TravelEtiquette />
+        </v-row>
+      </v-card>
+    </v-container>
+
+<v-container v-else>
       <v-row>
         <About />
       </v-row>
@@ -12,10 +54,7 @@
             <v-col cols="12" sm="10" md="10" lg="5">
               <ButtonDefault to="/signup" class="button">
                 <template v-slot:label>
-                  <v-icon large color=#001858>
-                    mdi-account-plus
-                  </v-icon>
-                  新規会員登録
+                  <v-icon large color="#001858">mdi-account-plus</v-icon>新規会員登録
                   <p class="btn-text">はじめてご利用で履歴を残したい方</p>
                 </template>
               </ButtonDefault>
@@ -23,10 +62,7 @@
             <v-col cols="12" sm="10" md="10" lg="5">
               <ButtonDefault to="login" class="button">
                 <template v-slot:label>
-                  <v-icon large color=#001858>
-                    mdi-account-search
-                  </v-icon>
-                  ログイン
+                  <v-icon large color="#001858">mdi-account-search</v-icon>ログイン
                   <p class="btn-text">既に会員登録がお済みの方</p>
                 </template>
               </ButtonDefault>
@@ -34,10 +70,7 @@
             <v-col cols="12" sm="10" md="10" lg="5">
               <ButtonDefault to="travel_list" class="button">
                 <template v-slot:label @click="guestLogin">
-                  <v-icon large color=#001858>
-                    mdi-briefcase-account
-                  </v-icon>
-                  ゲストログイン
+                  <v-icon large color="#001858">mdi-briefcase-account</v-icon>ゲストログイン
                   <p class="btn-text">初めてのご利用で一回限りご利用の方</p>
                 </template>
               </ButtonDefault>
@@ -46,14 +79,12 @@
         </div>
       </v-row>
 
-      <v-card color=#f3d2c1>
+      <v-card color="#f3d2c1">
         <v-card-title primary-title class="justify-center">
-          <v-icon large color=#001858>
-            mdi-bag-checked
-          </v-icon>
+          <v-icon large color="#001858">mdi-bag-checked</v-icon>
           <span class="title">旅行出発前に知っておきたいこと</span>
         </v-card-title>
-        <v-card-text color=#001858>
+        <v-card-text color="#001858">
           <p>画像をクリックすると知っておきたい情報をチェックできます</p>
         </v-card-text>
         <v-row>
@@ -63,127 +94,130 @@
         </v-row>
       </v-card>
     </v-container>
+
+
   </div>
 </template>
 
 <script>
-  import NewTravel from "@/components/NewTravel";
-  import TravelList from "@/components/TravelList";
-  import axios from "@/plugins/axios";
-  import firebase from "@/plugins/firebase";
-  import Home from '~/components/Home.vue'; // 今回追加
-  import Train from '~/components/Train.vue';
-  import Air from '~/components/Air.vue';
-  import TravelEtiquette from '~/components/TravelEtiquette.vue';
-  import About from '~/components/About.vue';
-  import ButtonDefault from '~/components/ButtonDefault.vue';
+import NewTravel from "@/components/NewTravel";
+import TravelList from "@/components/TravelList";
+import axios from "@/plugins/axios";
+import firebase from "@/plugins/firebase";
+import Home from "~/components/Home.vue"; // 今回追加
+import Train from "~/components/Train.vue";
+import Air from "~/components/Air.vue";
+import TravelEtiquette from "~/components/TravelEtiquette.vue";
+import About from "~/components/About.vue";
+import ButtonDefault from "~/components/ButtonDefault.vue";
 
+export default {
+  components: {
+    NewTravel,
+    TravelList,
+    Home,
+    ButtonDefault
+  },
 
-
-  export default {
-    components: {
-      NewTravel,
-      TravelList,
-      Home,
-      ButtonDefault,
-
+  data() {
+    return {};
+  },
+  methods: {
+    async guestLogin() {
+      firebase
+        .auth()
+        .signInWithEmailAndPassword(
+          process.env.GUEST_LOGIN_EMAIL,
+          process.env.GUESTPW
+        )
+        .catch(error => {
+          console.log(error);
+          this.error = (code => {
+            switch (code) {
+              case "auth/user-not-found":
+                return "メールアドレスが間違っています";
+              case "auth/wrong-password":
+                return "※パスワードが正しくありません";
+              default:
+                return "※メールアドレスとパスワードをご確認ください";
+            }
+          })(error.code);
+        });
+      this.$router.push("/travel_list");
     },
-
-    data() {
-      return {
-
-      };
-
+    openModal() {
+      this.modalFlag = true;
     },
-    methods: {
-      async guestLogin() {
-        firebase
-          .auth()
-          .signInWithEmailAndPassword(process.env.GUEST_LOGIN_EMAIL, process.env.GUESTPW)
-          .catch(error => {
-            console.log(error);
-            this.error = (code => {
-              switch (code) {
-                case "auth/user-not-found":
-                  return "メールアドレスが間違っています";
-                case "auth/wrong-password":
-                  return "※パスワードが正しくありません";
-                default:
-                  return "※メールアドレスとパスワードをご確認ください";
-              }
-            })(error.code);
-          });
-        this.$router.push("/travel_list");
+    closeModal() {
+      this.modalFlag = false;
+    }
+    // .catch(error => {
+    //   console.log(error);
+    //   this.error = (code => {
+    //     switch (code) {
+    //       case "auth/user-not-found":
+    //         return "メールアドレスが間違っています";
+    //       case "auth/wrong-password":
+    //         return "※パスワードが正しくありません";
+    //       default:
+    //         return "※メールアドレスとパスワードをご確認ください";
+    //     }
+    //   })(error.code);
+    // });
+  },
+  computed: {
+      user() {
+        return this.$store.state.auth.currentUser;
       },
-      openModal() {
-        this.modalFlag = true
-      },
-      closeModal() {
-        this.modalFlag = false
-      }
-      // .catch(error => {
-      //   console.log(error);
-      //   this.error = (code => {
-      //     switch (code) {
-      //       case "auth/user-not-found":
-      //         return "メールアドレスが間違っています";
-      //       case "auth/wrong-password":
-      //         return "※パスワードが正しくありません";
-      //       default:
-      //         return "※メールアドレスとパスワードをご確認ください";
-      //     }
-      //   })(error.code);
-      // });
-    },
-    // },
-  };
+  }
 
+  // },
+};
 </script>
 
 <style lang="scss" scoped>
-  .button {
-    /* background-color: #f3d2c1; */
-    border: solid 5px #001858;
-    /*線*/
-    border-radius: 10px;
-    /*角の丸み*/
-    text-decoration: none;
-    display: flex;
-    -webkit-justify-content: center;
-    justify-content: center;
-    -webkit-align-items: center;
-    align-items: center;
-    box-shadow: 4px 4px #f582ae;
-  }
+.button {
+  /* background-color: #f3d2c1; */
+  border: solid 5px #001858;
+  /*線*/
+  border-radius: 10px;
+  /*角の丸み*/
+  text-decoration: none;
+  display: flex;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  align-items: center;
+  box-shadow: 4px 4px #f582ae;
+}
 
-  .page {
-    padding: 30px;
+.page {
+  padding: 30px;
 
-    >.buttons {
-      display: -webkit-flex;
+  > .buttons {
+    display: -webkit-flex;
 
-
-      >.button {}
+    > .button {
     }
   }
+}
 
-  .btn-text {
-    font-size: 12px;
-  }
+.btn-text {
+  font-size: 12px;
+}
 
-  p {
-    color: #001858;
-    text-align: center;
-  }
-
-  .v-card-title {
-    text-align: center;
-    font-weight: bolder;
-  }
-
-  .title{
+p {
   color: #001858;
   text-align: center;
 }
 
+.v-card-title {
+  text-align: center;
+  font-weight: bolder;
+}
+
+.title {
+  color: #001858;
+  text-align: center;
+}
 </style>


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#77  ログイン後のTOPページの構成
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
ログイン後のTOP画面に配置しているボタンの変更
ログイン後は「旅行登録」と「旅行一覧」ボタンが表示されるようにしました。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
<img width="1396" alt="スクリーンショット 2021-01-28 15 58 53" src="https://user-images.githubusercontent.com/71075728/106101780-bb8a2380-6181-11eb-90f4-05953389d4a4.png">
