### PR TITLE
Update travel new list

### DIFF
--- a/tabimae-web/pages/login.vue
+++ b/tabimae-web/pages/login.vue
@@ -61,7 +61,7 @@
       return {
         email: "",
         password: "",
-        show1: false,
+        show1: true,
         error: "",
       };
     },

--- a/tabimae-web/pages/signup.vue
+++ b/tabimae-web/pages/signup.vue
@@ -69,8 +69,8 @@
         name: "",
         password: "",
         passwordConfirm: "",
-        show1: false,
-        show2: false,
+        show1: true,
+        show2: true,
         error: "",
       };
     },


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#137  パスワード表示方法
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
パスワードの表示化をdefault:trueにしました。  
これにより、・・・で暗号化されて入力されていたパスワードが入力した値が直接表示されるようにしました。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
パスワード入力フォームのみフォントをdefaultに戻す方法も試みましたが、統一性も加味してフォントをそのままにする方法を選択しました。
<img width="723" alt="スクリーンショット 2021-02-08 21 11 12" src="https://user-images.githubusercontent.com/71075728/107217882-2d9c1b80-6a52-11eb-9018-36c03aa0c56c.png">
