### PR TITLE
Update responsive 2

### DIFF
--- a/tabimae-web/layouts/default.vue
+++ b/tabimae-web/layouts/default.vue
@@ -257,6 +257,9 @@ $sp: 480px;  // スマホ
             display: none;
           }
   }
+  .v-app-bar{
+    padding-left: 120px;
+  }
 </style>
 <style>
 .v-app-bar{

--- a/tabimae-web/layouts/default.vue
+++ b/tabimae-web/layouts/default.vue
@@ -258,7 +258,13 @@ $sp: 480px;  // スマホ
           }
   }
   .v-app-bar{
-    padding-left: 120px;
+      padding-left: 120px;
+          @include tab {
+      padding-left: 0px;
+          }
+          @include sp {
+      padding-left: 0px;
+          }
   }
 </style>
 <style>

--- a/tabimae-web/layouts/default.vue
+++ b/tabimae-web/layouts/default.vue
@@ -16,18 +16,7 @@
     </v-navigation-drawer>
     <v-app-bar fixed hide-on-scroll color="rgba(10,10,100,0.2)">
       <v-app-bar-nav-icon color="#001858" @click.stop="drawer = !drawer" />
-      <!-- <v-btn icon @click.stop="miniVariant = !miniVariant">
-        <v-icon>mdi-{{ `chevron-${miniVariant ? "right" : "left"}` }}</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="clipped = !clipped">
-        <v-icon>mdi-bag-checked</v-icon>
-      </v-btn>
-      <v-btn icon @click.stop="fixed = !fixed">
-        <v-icon>mdi-minus</v-icon>
-      </v-btn> -->
-      <!-- <v-btn @click="travelTop"> -->
         <img :src="image_src" @click="travelTop" class="new_travel_info-img">
-      <!-- </v-btn> -->
       <v-spacer />
 
       <v-container v-if="user" class="header-item">


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#149  ヘッダーアイテムの位置変更
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
header-itemのドロワーを開くv-iconの位置を、TOPページの余白と揃えました。  
また、設定している`padding-left: 120px;`はPCサイズにのみ適用しています。

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
<img width="1440" alt="スクリーンショット 2021-02-23 23 10 45" src="https://user-images.githubusercontent.com/71075728/108855451-5dd7e280-762c-11eb-96c0-55c8a8aa4072.png">
