### PR TITLE
Fix header2

### DIFF
--- a/tabimae-web/layouts/default.vue
+++ b/tabimae-web/layouts/default.vue
@@ -17,7 +17,7 @@
       </v-list>
     </v-navigation-drawer>
     <v-app-bar fixed hide-on-scroll color="rgba(10,10,100,0.2)">
-      <v-app-bar-nav-icon color="#001858" @click.stop="drawer = !drawer" />
+      <v-app-bar-nav-icon class="nav-menu-icon" color="#001858" @click.stop="drawer = !drawer" />
         <img :src="image_src" @click="travelTop" class="new_travel_info-img">
       <v-spacer />
 
@@ -198,15 +198,9 @@
 </script>
 
 <style lang="scss" scoped>
-$pc: 1024px; // PC
-$tab: 680px; // タブレット
+$tab: 768px; // タブレット
 $sp: 480px;  // スマホ
 
-@mixin pc {
-  @media (max-width: ($pc)) {
-    @content;
-  }
-}
 @mixin tab {
   @media (max-width: ($tab)) {
     @content;
@@ -266,7 +260,18 @@ $sp: 480px;  // スマホ
       padding-left: 0px;
           }
   }
+
+
+@media screen and (min-width:769px){
+/* PC用CSS -------------- */
+.nav-menu-icon{
+display: none;
+}
+}
+
 </style>
+
+
 <style>
 .v-app-bar{
 position: relative;


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#205 ドロワーアイコンの非表示
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
PC以下サイズの時のみドロワーアイコン(mdi-menu)を表示するようにしました。
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
<img width="1284" alt="スクリーンショット 2021-06-18 20 52 38" src="https://user-images.githubusercontent.com/71075728/122556963-1fe94900-d077-11eb-84fd-4dd8aa0dd50a.png">
<img width="361" alt="スクリーンショット 2021-06-18 20 52 57" src="https://user-images.githubusercontent.com/71075728/122557008-2aa3de00-d077-11eb-8da4-2391b50a3e81.png">

