### PR TITLE
[本番環境]レスポンシブ最終調節

### DIFF
--- a/tabimae-web/components/about.vue
+++ b/tabimae-web/components/about.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
 
-    <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="0" lg="12">
+    <!-- <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="0" lg="12"> -->
       <v-card color=#fef6e4>
         <v-card-title primary-title class="justify-center">
           <v-icon x-large color=#e53170>
@@ -24,7 +24,7 @@
             旅行後（タビアト）に後悔のない素敵な旅行を”タビマエ”と創造しましょう！</p>
         </v-card-text>
       </v-card>
-    </v-col>
+    <!-- </v-col> -->
 
   </div>
 </template>

--- a/tabimae-web/pages/index.vue
+++ b/tabimae-web/pages/index.vue
@@ -35,7 +35,7 @@
         <div class="page">
           <div class="buttons">
             <v-row>
-            <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="0" lg="3">
+            <v-col cols="12" offset-lg="0" lg="3">
                 <ButtonDefault to="/signup" class="button">
                   <template v-slot:label>
                     <v-icon large color="#001858">mdi-account-plus</v-icon>
@@ -44,7 +44,7 @@
                   </template>
                 </ButtonDefault>
               </v-col>
-            <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="1" lg="3">
+            <v-col cols="12" offset-lg="1" lg="3">
                 <ButtonDefault to="login" class="button">
                   <template v-slot:label>
                     <v-icon large color="#001858">mdi-account-search</v-icon>
@@ -53,7 +53,7 @@
                   </template>
                 </ButtonDefault>
               </v-col>
-            <v-col cols="12" sm="8" offset-xs="3" xs="8" offset-md="3" md="9" offset-lg="1" lg="4">
+            <v-col cols="12"offset-lg="1" lg="4">
                 <div @click="guestLogin">
                 <GuestLoginButton class="guestLogin-button">
                   <template v-slot:label>

--- a/tabimae-web/pages/index.vue
+++ b/tabimae-web/pages/index.vue
@@ -6,7 +6,7 @@
         <div class="buttons">
 
           <v-row>
-            <v-col cols="12" offset-sm="1" sm="5" offset-md="2" md="2" offset-lg="1" lg="4">
+            <v-col cols="12" offset-lg="1" lg="4">
               <ButtonDefault to="/travelNew" class="traveladd-button">
                 <template v-slot:label class="test">
                   <v-icon large color="#001858">mdi-briefcase-plus-outline</v-icon>
@@ -16,7 +16,7 @@
               </ButtonDefault>
             </v-col>
 
-            <v-col offset-sm="1" sm="5" offset-md="2" md="10" offset-lg="" lg="4">
+            <v-col cols="12" offset-lg="2" lg="4">
               <ButtonDefault to="/travelList" class="travellist-button">
                 <template v-slot:label>
                   <v-icon large color="#001858">mdi-format-list-bulleted</v-icon>

--- a/tabimae-web/pages/logOut.vue
+++ b/tabimae-web/pages/logOut.vue
@@ -1,7 +1,7 @@
 <template>
 <v-app class="bg">
     <!-- <v-row> -->
-    <v-col cols="12" sm="10" md="6" lg="6" offset-lg="3">
+    <v-col cols="12" lg="6" offset-lg="3">
       <v-card color=#f3d2c1 class="guestcard">
         <v-card-title primary-title class="justify-center">
         </v-card-title>

--- a/tabimae-web/pages/login.vue
+++ b/tabimae-web/pages/login.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app class="bg">
     <v-row>
-      <v-col cols="12" sm="10" md="6" lg="6" offset-lg="3">
+      <v-col cols="12" lg="6" offset-lg="3">
         <v-card color=#8bd3dd class="login-card">
           <v-card-title primary-title class="justify-center">
             <v-icon x-large color=#e53170>
@@ -30,9 +30,9 @@
         </v-card>
       </v-col>
     </v-row>
-    <v-row>
-      <v-col cols="12" sm="10" md="6" lg="6" offset-lg="3">
 
+    <v-row>
+      <v-col cols="12" lg="6" offset-lg="3">
         <v-card color=#f3d2c1>
           <v-card-title primary-title class="justify-center">
             <v-icon x-large color=#e53170>

--- a/tabimae-web/pages/signup.vue
+++ b/tabimae-web/pages/signup.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app class="bg">
     <v-row>
-      <v-col cols="12" sm="10" md="6" lg="6" offset-lg="3">
+      <v-col cols="12" lg="6" offset-lg="3">
         <v-card color="#8bd3dd" class="signup-card">
           <v-card-title primary-title class="justify-center">
             <v-icon x-large color="#e53170">
@@ -66,7 +66,7 @@
     </v-row>
 
     <v-row>
-      <v-col cols="12" sm="10" md="6" lg="6" offset-lg="3">
+      <v-col cols="12" lg="6" offset-lg="3">
         <v-card color="#f3d2c1">
           <v-card-title primary-title class="justify-center">
             <v-icon x-large color="#e53170">

--- a/tabimae-web/pages/travel/_id.vue
+++ b/tabimae-web/pages/travel/_id.vue
@@ -87,7 +87,7 @@
           </v-card>
         </v-col>
 
-        <v-col cols="12" sm="11" md="11" lg="9">
+        <v-col cols="12" lg="9">
           <v-card color="#001858" elevation="20">
             <v-row>
               <v-col cols="12" sm="11" md="11" lg="12">

--- a/tabimae-web/pages/travel/_id.vue
+++ b/tabimae-web/pages/travel/_id.vue
@@ -3,7 +3,7 @@
 
     <v-container>
       <v-row>
-        <v-col cols="12" sm="11" md="11" lg="12">
+        <v-col cols="12" lg="12">
           <v-card color="#f3d2c1" class="travelshow-card">
             <v-card-title primary-title class="justify-center">
               <v-icon x-large color=#e53170>
@@ -21,7 +21,7 @@
 
     <v-container>
       <v-row>
-        <v-col cols="12" sm="11" md="11" lg="3">
+        <v-col cols="12" lg="3">
           <v-card color="#001858" elevation="24">
             <v-card-title primary-title class="justify-center">
               <v-icon large>mdi-bag-checked</v-icon>

--- a/tabimae-web/pages/travelList.vue
+++ b/tabimae-web/pages/travelList.vue
@@ -2,7 +2,7 @@
   <v-app class="bg">
     <v-container>
       <v-row>
-        <v-col cols="12" offset-ms="1" sm="10" offset-md="1" md="11" offset-lg="1" lg="10">
+        <v-col cols="12" offset-lg="1" lg="10">
           <v-card color="#ffc6c7" elevation="2" class="travellist-card">
             <v-card-title primary-title class="justify-center">
               <v-icon x-large color=#e53170>
@@ -20,7 +20,7 @@
 
     <v-container>
       <v-row>
-        <v-col cols="12" sm="11" offset-md="1" md="11" lg="10">
+        <v-col cols="12" offset-lg="1" lg="10">
           <v-card elevation="10">
             <v-simple-table class="list-table" style="color:#001858">
               <thead class="list-thead">

--- a/tabimae-web/pages/travelNew.vue
+++ b/tabimae-web/pages/travelNew.vue
@@ -38,7 +38,7 @@
 
     <v-container>
       <v-row>
-        <v-col cols="12" offset-sm="2" sm="8" offset-md="1" md="11" offset-lg="2" lg="8">
+        <v-col cols="12" offset-lg="2" lg="8">
           <v-card v-if="transport === 'train'" color=#232946 elevation=“24”>
             <h1 class="transport-title">
               <v-icon large color=#fef6e4>mdi-train</v-icon>

--- a/tabimae-web/pages/travelNew.vue
+++ b/tabimae-web/pages/travelNew.vue
@@ -113,7 +113,7 @@
       </v-row>
 
       <v-row>
-        <v-col cols="12" offset-sm="1" sm="8" offset-md="1" md="11" offset-lg="2" lg="8">
+        <v-col cols="12" offset-lg="2" lg="8">
           <v-card v-if="transport === 'air'" color=#232946 elevation=“24”>
             <!-- <template v-if="transport === 'train'"> -->
             <h1 class="transport-title">

--- a/tabimae-web/pages/travelNew.vue
+++ b/tabimae-web/pages/travelNew.vue
@@ -2,7 +2,7 @@
   <v-app class="bg">
     <v-container>
       <v-row>
-        <v-col cols="12" offset-ms="1" sm="10" offset-md="1" md="11" offset-lg="1" lg="10">
+        <v-col cols="12" offset-lg="1" lg="10">
           <v-card color=#f9bc60 elevation=“20” class="travelnew-card">
             <v-card-title primary-title class="justify-center">
               <v-icon x-large color=#e53170>
@@ -21,7 +21,7 @@
 
     <v-container>
       <v-row>
-        <v-col cols="12" sm="11" offset-md="1" md="11" offset-lg="2" lg="8">
+        <v-col cols="12" offset-lg="2" lg="8">
           <h2 v-if="success">登録したよ!</h2>
           <v-card elevation=“20”>
             <v-container fluid class="transport-radio">


### PR DESCRIPTION
# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#149 レスポンシブ※ipad/ipad proサイズ
# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
デスクトップ、PC、スマホのみに対応していましたが、タブレットでも画面が整うように調節しました。
# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
<img width="386" alt="スクリーンショット 2021-06-19 1 36 01" src="https://user-images.githubusercontent.com/71075728/122592004-b5e49a00-d09e-11eb-89ad-6ebc7740da82.png">
<img width="386" alt="スクリーンショット 2021-06-19 1 36 28" src="https://user-images.githubusercontent.com/71075728/122592040-c5fc7980-d09e-11eb-8760-84d96366545a.png">

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
<v-col cols="12" lg="6" offset-lg="3">で基本的には、colsとlgのみで記述し、sm/mdを削除<br>
全画面修正しました。